### PR TITLE
Feature/direct job runs

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
 using MoneyBurned.Dotnet.Lib;
 using MoneyBurned.Dotnet.Lib.Data;
 
@@ -11,6 +12,7 @@ internal class Program
 {
     private static bool resComplete = false;
     private static bool nicePrint = false;
+    private static bool directRun = false;
     private static int redraws = 0;
     private static readonly List<Resource> resources = [];
     private static Job? job;
@@ -37,7 +39,10 @@ internal class Program
                         case "--nice":
                             nicePrint = true;
                             break;
-                        
+                        case "-d":
+                        case "--direct-run":
+                            directRun = true;
+                            break;
                         case "-c":
                         case "--cost-types":
                             PrintCostTypes();
@@ -51,7 +56,10 @@ internal class Program
                 }
             }
 
-            DrawScreen();
+            if (!directRun)
+            {
+                DrawScreen();
+            }
             RunJob();
         }
         catch (IndexOutOfRangeException)
@@ -110,7 +118,10 @@ internal class Program
         Console.CancelKeyPress += (sender, e) =>
         {
             e.Cancel = true;
-            Console.WriteLine($"CancelKeyPress event triggered by user '{e.SpecialKey}'. Exiting...");
+            job!.EndRecording();
+            Console.WriteLine();
+            Console.WriteLine($"Job aborted by '{e.SpecialKey}'...");
+            Console.WriteLine(job);
             Environment.Exit(0);
             return;
         };
@@ -119,17 +130,25 @@ internal class Program
         var posLeft = Console.CursorLeft;
 
         job = new Job([.. resources]);
-        Console.Write("Press Return to start or Ctrl+C to abort...");
-        Console.Read();
+        if (!directRun)
+        {
+            Console.Write("Press Return to start or Ctrl+C to abort...");
+            Console.Read();
+        }
 
         job.StartRecording();
         if (nicePrint) { Console.SetCursorPosition(posLeft, posTop); }
-        Console.Write("Recording - press Return to stop recording...    ");
+        Console.Write("Recording - press Return or Ctrl+C to stop recording...    ");
         int i = 1;
         int lastKey = 0;
         do
         {
-            if (nicePrint)
+            if (directRun)
+            {
+                CenterText($"{job.ElapsedCost:C2}");
+                Thread.Sleep(1000);
+            }
+            else if (nicePrint)
             {
                 Console.SetCursorPosition(posLeft, posTop + 1);
                 if (i % 2 == 0) { Console.Write("  [/] {0:C2}", job.ElapsedCost); }
@@ -221,6 +240,57 @@ internal class Program
     }
 
     /// <summary>
+    /// Prints full screen centered text to console
+    /// </summary>
+    /// <param name="centerText">Text to display; can be multiple lines</param>
+    /// <param name="leftOffset">Left offset</param>
+    /// <param name="topOffset">Top offset</param>
+    private static void CenterText(string centerText, int leftOffset = 0, int topOffset = 0)
+    {
+        if (string.IsNullOrEmpty(centerText))
+        {
+            return;
+        }
+
+        int middleWidth;
+        int middleHeight;
+
+        try
+        {
+            centerText = centerText.ReplaceLineEndings();
+            string[] lines = centerText.Split([Environment.NewLine], StringSplitOptions.None);
+            int horizontalMiddle = 0;
+            foreach (string line in lines)
+            {
+                horizontalMiddle = line.Length > horizontalMiddle ? Convert.ToInt32(line.Length / 2) : horizontalMiddle;
+            }
+
+            middleWidth = Convert.ToInt32(Console.WindowWidth / 2) - horizontalMiddle + leftOffset;
+            middleHeight = Convert.ToInt32(Console.WindowHeight / 2) + topOffset - Convert.ToInt32(lines.Length / 2);
+            Console.Clear();
+            for (int i = 0; i < lines.Length; i++)
+            {
+                Console.SetCursorPosition(middleWidth, middleHeight);
+                Console.Write(lines[i]);
+                middleHeight++;
+            }
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            middleWidth = Convert.ToInt32(Console.WindowWidth / 2) - 13;
+            middleHeight = Convert.ToInt32(Console.WindowHeight / 2) - 1;
+            Console.SetCursorPosition(middleWidth, middleHeight);
+            Console.Write("# !Output Area to small! #");
+            Console.SetCursorPosition(middleWidth, middleHeight + 1);
+            Console.Write("# Please enlarge console #");
+        }
+        catch (Exception ex)
+        {
+            Console.Write($"Writing output failed with {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
     /// Prints the applications logo
     /// </summary>
     private static void PrintLogo()
@@ -259,6 +329,7 @@ Options:
                                    You are allowed to use common interval types to specify costs  
                                    scoped not only to hourly bases (e. g. MD = man days, d = days).
   -c, --cost-types                 Lists all available cost interval types.
+  -d, --direct-run                 Starts the job immediately when resources are available.
   -n, --nice                       Enables a more interactive and nice looking user experience.
   -?, -h, --help                   Show help and usage information.
 ";

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -107,6 +107,14 @@ internal class Program
             return;
         }
 
+        Console.CancelKeyPress += (sender, e) =>
+        {
+            e.Cancel = true;
+            Console.WriteLine($"CancelKeyPress event triggered by user '{e.SpecialKey}'. Exiting...");
+            Environment.Exit(0);
+            return;
+        };
+
         var posTop = Console.CursorTop;
         var posLeft = Console.CursorLeft;
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using System.Security.Cryptography.X509Certificates;
 using MoneyBurned.Dotnet.Lib;
 using MoneyBurned.Dotnet.Lib.Data;
 
@@ -40,7 +39,7 @@ internal class Program
                             nicePrint = true;
                             break;
                         case "-d":
-                        case "--direct-run":
+                        case "--disable-direct-run":
                             directRun = true;
                             break;
                         case "-c":
@@ -54,6 +53,9 @@ internal class Program
                             break;
                     }
                 }
+
+                // if resources are added already, switch to direct mode, except 'disable-direct-run' was selected
+                if (resources.Count > 0) { directRun = !directRun; }
             }
 
             if (!directRun)
@@ -120,9 +122,6 @@ internal class Program
             e.Cancel = true;
             job!.EndRecording();
             Console.WriteLine();
-            Console.WriteLine($"Job aborted by '{e.SpecialKey}'...");
-            Console.WriteLine(job);
-            Environment.Exit(0);
             return;
         };
 
@@ -138,7 +137,7 @@ internal class Program
 
         job.StartRecording();
         if (nicePrint) { Console.SetCursorPosition(posLeft, posTop); }
-        Console.Write("Recording - press Return or Ctrl+C to stop recording...    ");
+        Console.WriteLine("Recording - press Return or Ctrl+C to stop recording...    ");
         int i = 1;
         int lastKey = 0;
         do
@@ -162,11 +161,10 @@ internal class Program
             }
             if (Console.KeyAvailable) { lastKey = Console.Read(); }
             i++;
-        } while (lastKey != 13);
+        } while (lastKey != 13 && !(job.EndTime != DateTime.MaxValue));
 
         job.EndRecording();
-        Console.WriteLine();
-        Console.WriteLine(job);
+        SummarizeJob();
     }
 
     #region UI support
@@ -195,7 +193,7 @@ internal class Program
             {
                 foreach (Resource resource in resources)
                 {
-                    Console.WriteLine("  - {0}", resource);
+                    Console.WriteLine($"  - {resource}");
                 }
             }
             else
@@ -237,6 +235,17 @@ internal class Program
             }
             if (nicePrint) { DrawScreen(); }
         }
+    }
+
+    /// <summary>
+    /// Summarize job recording
+    /// </summary>
+    private static void SummarizeJob()
+    {
+        if (nicePrint || directRun) { Console.Clear(); }
+        if (nicePrint) { PrintLogo(); }
+        if (!directRun) { Console.WriteLine("--------------------------------------------------------------------"); }
+        if (job != null) { Console.WriteLine(job); }
     }
 
     /// <summary>
@@ -327,9 +336,13 @@ Options:
                                    each resource separator before the cost value. 
                                    (e. g. for 3 resources: ""24,99;Manager:89;11"")
                                    You are allowed to use common interval types to specify costs  
-                                   scoped not only to hourly bases (e. g. MD = man days, d = days).
-  -c, --cost-types                 Lists all available cost interval types.
-  -d, --direct-run                 Starts the job immediately when resources are available.
+                                   scoped not only to hourly bases (e. g. MD = man days, d = days). 
+                                   **BE AWARE** If the resources have been processed successfully and 
+                                   you have at least one resource defined, the job will start immediately 
+                                   in full-screen mode with centered output!
+  -c, --cost-types                 Lists all available cost interval types and a few sample resource strings.
+  -d, --disable-direct-run         Prevent immediately jobe execution, even if resources are configured
+                                   to have the opportunity to add more resources in interactive mode.
   -n, --nice                       Enables a more interactive and nice looking user experience.
   -?, -h, --help                   Show help and usage information.
 ";

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -15,6 +15,7 @@ internal class Program
     private static int redraws = 0;
     private static readonly List<Resource> resources = [];
     private static Job? job;
+    private static string? jobName;
 
     /// <summary>
     /// Main method that processes the arguments and executes the most important application methods in the correct order
@@ -30,6 +31,10 @@ internal class Program
                 {
                     switch (args[i].Trim().ToLower())
                     {
+                        case "-j":
+                        case "--job-name":
+                            jobName = args[i + 1];
+                            break;
                         case "-r":
                         case "--resources":
                             ReadResources(args[i + 1]);
@@ -129,6 +134,7 @@ internal class Program
         var posLeft = Console.CursorLeft;
 
         job = new Job([.. resources]);
+        job.Name = string.IsNullOrWhiteSpace(jobName) ? $"Job_{DateTime.Now:yyMMdd_HHmmss}" : jobName;
         if (!directRun)
         {
             Console.Write("Press Return to start or Ctrl+C to abort...");
@@ -330,6 +336,7 @@ Usage:
   MoneyBurned.Cli [options]
 
 Options:
+  -n <name>, --job-name <name>     Give it a descriptive name if you wish - it's just for convenience.
   -r <resource string>,            Starts the tool including a set of resources, given as string. 
   --resources <resource string>    A resource string is separated by a semicolon or plus sign for 
                                    cost. If you need to assign names, use a colon as an additional 


### PR DESCRIPTION
- added feature for starting the job immediately if resources are present
- direct run will have output centered in full-screen mode
- direct run in full-screen mode must not be explicitly enforced and is controlled by successful resource processing
- direct run can be prevented if interactive mode is required
- consistent behavior when outputting the summary for both options for ending a job
- updated help dialog
- added job name option